### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 on: [push, pull_request]
 
 name: CI
+permissions:
+  contents: read
 
 jobs:
   linux:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/1](https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden at the job level. Based on the workflow's actions, the minimal required permissions are likely `contents: read`. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
