### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -26,6 +26,9 @@ on:
     branches: [ "349/paragraph-scroll" ]
   pull_request:
     branches: [ "349/paragraph-scroll" ]
+permissions:
+  contents: read
+  security-events: write
 jobs:
   appknox:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/3](https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- The `contents: read` permission is required to check out the code.
- The `security-events: write` permission is required to upload SARIF files to GitHub Advanced Security.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as this workflow does not define multiple jobs with differing permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
