### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,6 +54,8 @@ jobs:
   publish-stable:
     name: Create a stable release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout the repository


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/8](https://github.com/Git-Hub-Chris/Ratatui/security/code-scanning/8)

To fix the issue, add an explicit `permissions` block to the `publish-stable` job. This block should specify the minimal permissions required for the job to function correctly. Based on the operations performed in the job, the `contents: read` permission is sufficient for checking out the repository, and no additional permissions are needed unless explicitly required for other steps.

The `permissions` block should be added directly under the `runs-on` key in the `publish-stable` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
